### PR TITLE
Python 3 namespace packaging.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,7 @@ import os
 import sys
 import codecs
 
-
-try:
-	from setuptools.core import setup, find_packages
-except ImportError:
-	from setuptools import setup, find_packages
-
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
@@ -82,15 +77,8 @@ setup(
 				"Topic :: Software Development :: Libraries :: Python Modules",
 			],
 		
-		packages = find_packages(exclude=['documentation', 'example', 'test']),
+		packages = ('web.ext', 'web.template', 'web.template.serialize', 'web.template.template'),
 		include_package_data = True,
-		namespace_packages = [
-			'web',  # primary namespace
-			'web.ext',  # WebCore template extension
-			'web.template',  # engine namespace
-			'web.template.serialize',  # serialization engines
-			'web.template.template',  # template engines
-		],
 		
 		entry_points = {
 				'web.template': [

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
 				"Topic :: Software Development :: Libraries :: Python Modules",
 			],
 		
-		packages = ('web.ext', 'web.template', 'web.template.serialize', 'web.template.template'),
+		packages = ('web.ext', 'web.ext.template', 'web.template', 'web.template.serialize', 'web.template.template'),
 		include_package_data = True,
 		
 		entry_points = {

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__) # pragma: no-cover

--- a/web/ext/__init__.py
+++ b/web/ext/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__) # pragma: no-cover

--- a/web/template/__init__.py
+++ b/web/template/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__) # pragma: no-cover


### PR DESCRIPTION
> Care of [CEGID](https://www.cegid.com/global/), my current employer, there are a collection of downstream changes utilized by the [RITA](https://www.cegid.com/global/products/cegid-rita/) job offer multi-posting platform. This pull request aims to homogenize the changes, eliminate the need to pin specific branches instead of released versions, and generally improve the project.

Simple packaging update for modern Python 3 namespaces. Avoids a conflict with old-style (`pkg_resources`-based) namespaces where the two can not be mixed.